### PR TITLE
Upgrade to python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,26 @@
-FROM apache/airflow:2.7.3-python3.10
+FROM apache/airflow:slim-2.9.3-python3.12
 
-USER root 
-
-ARG AIRFLOW_HOME=/opt/airflow 
-
-ADD dags /opt/airflow/dags 
-
-ADD airflow.cfg /opt/airflow/airflow.cfg
-
-USER airflow
-
-RUN pip install --upgrade pip 
+ARG AIRFLOW_HOME=/opt/airflow
 
 USER root
 
-# MySQL key rotation (https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html)
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A8D3785C
-
 RUN apt-get update -y
-RUN apt-get install git -y
-RUN apt-get install lftp -y
-RUN apt-get install zip -y
-RUN apt-get install wget -y
-RUN apt-get install p7zip-full -y
+RUN apt-get install git lftp zip wget p7zip-full -y
 
 RUN chown -R "airflow:root" /opt/airflow/
-
 ADD ssh /home/airflow/.ssh/
 RUN chown -R airflow:root /home/airflow/.ssh
 
-USER airflow 
-
-RUN pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org boto3
-
-
-# USER ${AIRFLOW_UID}
 USER airflow
 
+RUN pip install --upgrade pip
+RUN pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org boto3
 ADD requirements.txt /requirements.txt
-
 RUN pip install -r /requirements.txt
 
-RUN git config --global user.email "geoffrey.aldebert@data.gouv.fr"
-RUN git config --global user.name "Geoffrey Aldebert (Bot Airflow)"
+ARG USER_NAME
+ARG USER_EMAIL
+RUN git config --global user.email "${USER_EMAIL}"
+RUN git config --global user.name "${USER_NAME}"
 
+ADD airflow.cfg /opt/airflow/airflow.cfg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
-version: "3"
 services:
   postgres:
     image: postgres:12
-    user: "${AIRFLOW_UID}:${AIRFLOW_GID}"
+    user: root
     volumes:
       - ./pg-airflow:/var/lib/postgresql/data
+    restart: unless-stopped
     env_file:
       - .env
     ports:
@@ -14,15 +14,19 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+          - USER_EMAIL=$USER_EMAIL
+          - USER_NAME=$USER_NAME
     hostname: webserver
-    restart: always
+    restart: unless-stopped
     depends_on:
       - postgres
     command: webserver
     env_file:
       - .env
     volumes:
-      - ./dags:/opt/airflow/dags
+      - ${LOCAL_AIRFLOW_DAG_PATH}:/opt/airflow/dags/dag_datalake_sirene/
+      - ${LOCAL_TMP_PATH}:/tmp
       - ./scripts:/opt/airflow/scripts
       - ./logs:/opt/airflow/logs
       - ./plugins:/opt/airflow/plugins

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,5 @@ pytest==7.2.1
 langdetect==1.0.9
 pydantic==2.10.5
 pyproj==3.7.0
+psycopg2-binary==2.9.10
+redis==5.2.1


### PR DESCRIPTION
Related to https://github.com/annuaire-entreprises-data-gouv-fr/search-infra/issues/469

The code seems to work flawlessly with Python 3.12.

Notes:
- Issues also true for the previous version of Python:
  - I had to update slightly the Dockerfile to make it work
  - `psycopg2-binary` and `redis` were missing from the requirements for the DAGs to run. How does it work in production? I thought that the `requirements.txt` of this repo was the source of truth @MKCG 
- `docker-compose.yaml` has been adapted to make local dev more custom
- I could not run locally a few DAGs:
  - RNE
  - ETL
  - data.gouv publish
  - elasticsearch.

I think we can deploy 3.12 to staging first and then prod. Or even directly to all the environments if there is not possibility to do it in stages. The risk of a critical issue is low.